### PR TITLE
feat: only allow lambda to tag objects

### DIFF
--- a/aws/s3-scan-object/locals.tf
+++ b/aws/s3-scan-object/locals.tf
@@ -1,0 +1,5 @@
+data "aws_caller_identity" "current" {}
+locals {
+  account_id      = data.aws_caller_identity.current.account_id
+  lambda_role_arn = "arn:aws:iam::${local.account_id}:role/s3-scan-object"
+}

--- a/aws/s3-scan-object/s3.tf
+++ b/aws/s3-scan-object/s3.tf
@@ -13,6 +13,63 @@ module "upload_bucket" {
 }
 
 #
+# Bucket policy
+#
+resource "aws_s3_bucket_policy" "upload_bucket" {
+  bucket = module.upload_bucket.s3_bucket_id
+  policy = data.aws_iam_policy_document.upload_bucket.json
+}
+
+data "aws_iam_policy_document" "upload_bucket" {
+  source_policy_documents = [
+    data.aws_iam_policy_document.limit_tagging.json
+  ]
+}
+
+#
+# Only allow the lambda to add object tags
+# to upload bucket
+#
+data "aws_iam_policy_document" "limit_tagging" {
+  statement {
+    effect = "Deny"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:DeleteObjectTagging",
+      "s3:DeleteObjectVersionTagging",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging"
+    ]
+    resources = [
+      "${module.upload_bucket.s3_bucket_arn}/*"
+    ]
+    condition {
+      test     = "StringNotLike"
+      variable = "aws:PrincipalArn"
+      values   = [local.lambda_role_arn]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = [local.lambda_role_arn]
+    }
+    actions = [
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging"
+    ]
+    resources = [
+      "${module.upload_bucket.s3_bucket_arn}/*"
+    ]
+  }
+}
+
+#
 # Trigger scan when file is created
 #
 resource "aws_lambda_permission" "s3_execute" {

--- a/aws/s3-scan-object/sns.tf
+++ b/aws/s3-scan-object/sns.tf
@@ -20,7 +20,6 @@ resource "aws_kms_key" "sns_lambda" {
   policy      = data.aws_iam_policy_document.sns_lambda.json
 }
 
-data "aws_caller_identity" "current" {}
 data "aws_iam_policy_document" "sns_lambda" {
   statement {
     effect    = "Allow"
@@ -29,7 +28,7 @@ data "aws_iam_policy_document" "sns_lambda" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+      identifiers = ["arn:aws:iam::${local.account_id}:root"]
     }
   }
 


### PR DESCRIPTION
# Summary
Limits object tagging in the upload bucket to the
Lambda function only.