### PR TITLE
feat: allow Scan Files to download from S3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,10 @@ name: Docker image build
 on:
   push:
     branches: [main]
+    paths: [lambda/**]
   pull_request:
     branches: [main]
+    paths: [lambda/**]
 
 env:
   DOCKER_BUILDKIT: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,10 @@ name: Test lambda code
 on:
   push:
     branches: [main]
+    paths: [lambda/**]
   pull_request:
     branches: [main]
+    paths: [lambda/**]
 
 jobs:
   test-lambda-code:

--- a/aws/s3-scan-object/inputs.tf
+++ b/aws/s3-scan-object/inputs.tf
@@ -4,6 +4,12 @@ variable "scan_files_api_key" {
   type        = string
 }
 
+variable "scan_files_role_arn" {
+  description = "Scan Files lambda execution role ARN"
+  sensitive   = true
+  type        = string
+}
+
 variable "scan_files_url" {
   description = "Scan Files URL"
   default     = "https://scan-files.alpha.canada.ca"

--- a/aws/s3-scan-object/s3.tf
+++ b/aws/s3-scan-object/s3.tf
@@ -22,7 +22,8 @@ resource "aws_s3_bucket_policy" "upload_bucket" {
 
 data "aws_iam_policy_document" "upload_bucket" {
   source_policy_documents = [
-    data.aws_iam_policy_document.limit_tagging.json
+    data.aws_iam_policy_document.limit_tagging.json,
+    data.aws_iam_policy_document.scan_files_download.json
   ]
 }
 
@@ -62,6 +63,41 @@ data "aws_iam_policy_document" "limit_tagging" {
     actions = [
       "s3:PutObjectTagging",
       "s3:PutObjectVersionTagging"
+    ]
+    resources = [
+      "${module.upload_bucket.s3_bucket_arn}/*"
+    ]
+  }
+}
+
+#
+# Allow Scan Files to download objects
+#
+data "aws_iam_policy_document" "scan_files_download" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = [var.scan_files_role_arn]
+    }
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket"
+    ]
+    resources = [
+      module.upload_bucket.s3_bucket_arn
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = [var.scan_files_role_arn]
+    }
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion"
     ]
     resources = [
       "${module.upload_bucket.s3_bucket_arn}/*"


### PR DESCRIPTION
# Summary
Update S3, KMS and SNS resource policies to allow the
Scan Files API execution role to directly download objects
from the S3 upload bucket.

This will save cost and time as the objects won't leave
the AWS network.