### PR TITLE
fix: undefined response from Scan Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,13 @@ If you want to test how the function handles an SNS message, you can publish a m
 ```sh
 cat > payload.json <<EOL 
 {
-    "Bucket": {
+    "av-filepath": {
         "DataType": "String",
-        "StringValue": "Samwise"
+        "StringValue": "s3://bucket-name/object-name.png"
     },
-    "Key": {
+    "av-status": {
         "DataType": "String",
-        "StringValue": "Gamgee"
-    },
-    "Result": {
-        "DataType": "String",
-        "StringValue": "POTAYTOES"
+        "StringValue": "clean"
     }
 }
 EOL

--- a/lambda/app.js
+++ b/lambda/app.js
@@ -7,6 +7,7 @@
  */
 
 const axios = require("axios");
+const util = require("util");
 const { S3Client, PutObjectTaggingCommand } = require("@aws-sdk/client-s3");
 const { SSMClient, GetParameterCommand } = require("@aws-sdk/client-ssm");
 
@@ -76,7 +77,8 @@ exports.handler = async (event) => {
         AWS_ACCOUNT_ID,
         SNS_SCAN_COMPLETE_TOPIC_ARN
       );
-      scanStatus = response.status === 200 ? SCAN_IN_PROGRESS : SCAN_FAILED_TO_START;
+      scanStatus =
+        response !== undefined && response.status === 200 ? SCAN_IN_PROGRESS : SCAN_FAILED_TO_START;
 
       // Get the scan status for an existing S3 object
     } else if (eventSource === EVENT_SNS) {
@@ -84,7 +86,7 @@ exports.handler = async (event) => {
 
       // Unknown event source
     } else {
-      console.error(`Unsupported event source: ${JSON.stringify(record)}`);
+      console.error(`Unsupported event source: ${util.inspect(record)}`);
     }
 
     // Tag the S3 object if we've got a scan status
@@ -174,11 +176,11 @@ const startS3ObjectScan = async (apiEndpoint, apiKey, s3Object, awsAccountId, sn
         },
       }
     );
-    console.log(`Response: ${JSON.stringify(response)}`);
+    console.info(`Scan response: ${util.inspect(response)}`);
     return response;
   } catch (error) {
     console.error(
-      `Could not start scan for ${JSON.stringify(s3Object)}: ${JSON.stringify(error.response)}`
+      `Could not start scan for ${util.inspect(s3Object)}: ${util.inspect(error.response)}`
     );
     return error.response;
   }

--- a/lambda/app.test.js
+++ b/lambda/app.test.js
@@ -236,6 +236,20 @@ describe("getS3ObjectFromRecord", () => {
     };
     expect(getS3ObjectFromRecord("aws:sns", record)).toEqual(expected);
   });
+
+  test("sns event, invalid av-filepath", () => {
+    const record = {
+      Sns: {
+        MessageAttributes: {
+          "av-filepath": {
+            Value: "file:///some.gif",
+          },
+        },
+      },
+    };
+    expect(getS3ObjectFromRecord("aws:sns", record)).toBe(null);
+  });
+
   test("invalid event", () => {
     expect(getS3ObjectFromRecord("muffins", {})).toBe(null);
   });

--- a/lambda/app.test.js
+++ b/lambda/app.test.js
@@ -158,7 +158,7 @@ describe("handler", () => {
         ],
       },
     });
-  });  
+  });
 
   test("records failed, invalid event source", async () => {
     const event = {


### PR DESCRIPTION
# Summary
* Handle an undefined response from the `axios.post` request.
* Fix circular references when trying to output response errors.
* Use updated SNS MessageAttribute keys from Scan Files.